### PR TITLE
ENH force newer conda-build

### DIFF
--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge::conda-forge-ci-setup=2 conda-build
+conda install --yes --quiet conda-forge::conda-forge-ci-setup=2 conda-build>=3.16
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Current build status
 
 [![Linux](https://img.shields.io/circleci/project/github/conda-forge/xgboost-feedstock/master.svg?label=Linux)](https://circleci.com/gh/conda-forge/xgboost-feedstock)
 [![OSX](https://img.shields.io/travis/conda-forge/xgboost-feedstock/master.svg?label=macOS)](https://travis-ci.org/conda-forge/xgboost-feedstock)
-[![Windows](https://img.shields.io/appveyor/ci/conda-forge/xgboost-feedstock/master.svg?label=Windows)](https://ci.appveyor.com/project/conda-forge/xgboost-feedstock/branch/master)
+![Windows disabled](https://img.shields.io/badge/Windows-disabled-lightgrey.svg)
 
 Current release info
 ====================


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
