### PR TITLE
Drop compilers from pure Python packages

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,20 +55,14 @@ outputs:
   - name: py-xgboost
     script: install-py-xgboost.sh
     requirements:
-      build:
-        - {{ compiler('c') }}
-        - {{ compiler('cxx') }}
-        - llvm-openmp  # [osx]
       host:
         - {{ pin_subpackage('libxgboost', exact=True) }}
         - python
         - setuptools
         - pip
-        - llvm-openmp  # [osx]
       run:
         - {{ pin_subpackage('libxgboost', exact=True) }}
         - {{ pin_subpackage('_py-xgboost-mutex', exact=True) }}
-        - llvm-openmp  # [osx]
         - python
         - numpy
         - scipy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0003-Fix-R-package-mingw-w64-compiler-flags-remove-m64.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win or linux32 or py2k]
 
 requirements:


### PR DESCRIPTION
Based on discussion and inspection of xgboost, the Python packages appear to be pure packages. Meaning they do not build C/C++ bindings to xgboost library. As such they should not need compilers as part of their build environments. So this attempts to drop the compilers from the pure parts of the package.

It is worth noting the same is not true of the R packages, which use C++ as part of their bindings. So make sure to leave the compilers for the R packages.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
