### PR TITLE
Try dropping macOS compiler workaround

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,13 +2,6 @@
 
 # http://xgboost.readthedocs.io/en/latest/build.html
 
-if [[ $(uname) == Darwin ]]
-then
-    # make sure cmake can compile openmp code with clang
-    export DYLD_FALLBACK_LIBRARY_PATH=${PREFIX}/lib
-    clang_version=`${CC} --version | grep "clang version" | cut -d " " -f 3`
-fi
-
 {
   cmake \
     -G "Unix Makefiles" \


### PR DESCRIPTION
As the compiler stack on macOS was recently updated, try dropping this workaround for OpenMP support. Should fix the CI errors seen in a simple re-render.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Taken from PR ( https://github.com/conda-forge/xgboost-feedstock/pull/34 ).