### PR TITLE
Build R packages with CMake

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,8 +10,12 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_:
-        CONFIG: linux_
+      linux_r_base3.5.1:
+        CONFIG: linux_r_base3.5.1
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_r_base3.6:
+        CONFIG: linux_r_base3.6
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -10,8 +10,11 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      osx_:
-        CONFIG: osx_
+      osx_r_base3.5.1:
+        CONFIG: osx_r_base3.5.1
+        UPLOAD_PACKAGES: True
+      osx_r_base3.6:
+        CONFIG: osx_r_base3.6
         UPLOAD_PACKAGES: True
 
   steps:

--- a/.ci_support/linux_r_base3.5.1.yaml
+++ b/.ci_support/linux_r_base3.5.1.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'
+- '3.7'
+r_base:
+- 3.5.1

--- a/.ci_support/linux_r_base3.6.yaml
+++ b/.ci_support/linux_r_base3.6.yaml
@@ -1,21 +1,17 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '9'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '9'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -27,5 +23,4 @@ python:
 - '3.6'
 - '3.7'
 r_base:
-- 3.5.1
 - '3.6'

--- a/.ci_support/osx_r_base3.5.1.yaml
+++ b/.ci_support/osx_r_base3.5.1.yaml
@@ -1,17 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -24,4 +28,3 @@ python:
 - '3.7'
 r_base:
 - 3.5.1
-- '3.6'

--- a/.ci_support/osx_r_base3.6.yaml
+++ b/.ci_support/osx_r_base3.6.yaml
@@ -1,0 +1,30 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'
+- '3.7'
+r_base:
+- '3.6'

--- a/README.md
+++ b/README.md
@@ -37,17 +37,31 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux</td>
+              <td>linux_r_base3.5.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=master&jobName=linux&configuration=linux_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=master&jobName=linux&configuration=linux_r_base3.5.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx</td>
+              <td>linux_r_base3.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=master&jobName=osx&configuration=osx_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=master&jobName=linux&configuration=linux_r_base3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_r_base3.5.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=master&jobName=osx&configuration=osx_r_base3.5.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_r_base3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=master&jobName=osx&configuration=osx_r_base3.6" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,6 +8,20 @@
     -D CMAKE_BUILD_TYPE:STRING="Release" \
     -D CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
     -D CMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
+    "${SRC_DIR}"
+} || {
+  cat $SRC_DIR/CMakeFiles/CMakeOutput.log
+  cat $SRC_DIR/CMakeFiles/CMakeError.log
+  exit 1
+}
+make -j${CPU_COUNT}
+
+{
+  cmake \
+    -G "Unix Makefiles" \
+    -D CMAKE_BUILD_TYPE:STRING="Release" \
+    -D CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
+    -D CMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
     -D R_LIB:BOOL=ON \
     "${SRC_DIR}"
 } || {

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,6 +8,7 @@
     -D CMAKE_BUILD_TYPE:STRING="Release" \
     -D CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
     -D CMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
+    -D R_LIB:BOOL=ON \
     "${SRC_DIR}"
 } || {
   cat $SRC_DIR/CMakeFiles/CMakeOutput.log

--- a/recipe/install-r-xgboost.sh
+++ b/recipe/install-r-xgboost.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
 if [[ ${OSTYPE} == msys ]]; then
-  if [[ ${r_implementation} == mro-base ]]; then
-    PREFIX=$(cygpath -u ${PREFIX})
-    # TODO :: Shouldn't our Rtools package set this?
-    export BINPREF=${PREFIX}/Rtools/mingw_64/bin/
-  fi
+  # Just for now; should we handle slash fixing in conda-build?
+  PREFIX=${PREFIX//\\//}
+  SRC_DIR=${SRC_DIR//\\//}
 fi
 
-pushd ${SRC_DIR}/R-package
-  # Remove src/Makevars.win because it says:
-  # This file is only used for windows compilation from github
-  # It will be replaced with Makevars.in for the CRAN version
-  # rm src/Makevars.win
-  ${R} CMD INSTALL --build .
-popd
+if [[ ${OSTYPE} == msys ]]; then
+  LIBDIR=${PREFIX}/Library/mingw-w64/lib
+else
+  LIBDIR=${PREFIX}/lib
+fi
+
+mkdir -p ${LIBDIR}/R || true
+cp -Rf ${SRC_DIR}/lib/R ${LIBDIR}/R/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0003-Fix-R-package-mingw-w64-compiler-flags-remove-m64.patch
 
 build:
-  number: 4
+  number: 5
   skip: true  # [win or linux32 or py2k]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - cmake
     - make
     - llvm-openmp  # [osx]
+    - r-base
   host:
     - llvm-openmp  # [osx]
     - r-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - llvm-openmp  # [osx]
   host:
     - llvm-openmp  # [osx]
+    - r-base
 
 outputs:
   - name: libxgboost


### PR DESCRIPTION
Switches the build of the R bindings to use CMake. As part of this, the R bindings are now built as part of the overall build step. This should ensure that the packages are built with OpenMP support on macOS.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/xgboost-feedstock/issues/41

<!--
Please add any other relevant info below:
-->
