### PR TITLE
Allow using relative paths to find conda prefix directory

### DIFF
--- a/recipe/0001-conda-Unbundle-libxgboost.-dll-dylib-so.patch
+++ b/recipe/0001-conda-Unbundle-libxgboost.-dll-dylib-so.patch
@@ -25,17 +25,25 @@ index d4b6aa6..a81adfa 100644
        classifiers=['License :: OSI Approved :: Apache Software License'],
        url='https://github.com/dmlc/xgboost')
 diff --git a/python-package/xgboost/libpath.py b/python-package/xgboost/libpath.py
-index d87922c..8158b5a 100644
+index 4d276050..46d06ed5 100644
 --- a/python-package/xgboost/libpath.py
 +++ b/python-package/xgboost/libpath.py
-@@ -24,6 +24,10 @@ def find_lib_path():
+@@ -23,6 +23,17 @@ def find_lib_path():
      dll_path = [curr_path, os.path.join(curr_path, '../../lib/'),
                  os.path.join(curr_path, './lib/'),
                  os.path.join(sys.prefix, 'xgboost')]
++    conda_prefix = os.path.join(curr_path, '../../../..')
 +    if sys.platform == 'win32':
-+        dll_path = [os.path.join(os.path.join(curr_path, '../../../..'), 'Library', 'mingw-w64', 'bin')]
++        dll_path = [
++             os.path.join(sys.prefix, 'Library', 'mingw-w64', 'bin'),
++             os.path.join(conda_prefix, 'Library', 'mingw-w64', 'bin')
++        ]
 +    else:
-+        dll_path = [os.path.join(os.path.join(curr_path, '../../../..'), 'lib')]
++        dll_path = [
++             os.path.join(sys.prefix, 'lib'),
++             os.path.join(conda_prefix, 'lib')
++        ]
      if sys.platform == 'win32':
          if platform.architecture()[0] == '64bit':
              dll_path.append(os.path.join(curr_path, '../../windows/x64/Release/'))
+

--- a/recipe/0001-conda-Unbundle-libxgboost.-dll-dylib-so.patch
+++ b/recipe/0001-conda-Unbundle-libxgboost.-dll-dylib-so.patch
@@ -33,9 +33,9 @@ index d87922c..8158b5a 100644
                  os.path.join(curr_path, './lib/'),
                  os.path.join(sys.prefix, 'xgboost')]
 +    if sys.platform == 'win32':
-+        dll_path = [os.path.join(sys.prefix, 'Library', 'mingw-w64', 'bin')]
++        dll_path = [os.path.join(os.path.join(curr_path, '../../../..'), 'Library', 'mingw-w64', 'bin')]
 +    else:
-+        dll_path = [os.path.join(sys.prefix, 'lib')]
++        dll_path = [os.path.join(os.path.join(curr_path, '../../../..'), 'lib')]
      if sys.platform == 'win32':
          if platform.architecture()[0] == '64bit':
              dll_path.append(os.path.join(curr_path, '../../windows/x64/Release/'))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0003-Fix-R-package-mingw-w64-compiler-flags-remove-m64.patch
 
 build:
-  number: 4
+  number: 5
   skip: true  # [win or linux32 or py2k]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This allows the package to be imported by another python runtime, with e.g.

```
import site
site.addsitedir("<conda_site_packages>")
```

Without this change, the other python runtime's `sys.prefix` is used, and `XGBoostLibraryNotFound` is thrown.

With this change, the other python runtime can find `libxgboost.so` relative to `libpath.py`. Here are the paths from the conda root:

```
$ find . -name libxgboost.so
./lib/libxgboost.so
$ find . -name libpath.py
./lib/python3.6/site-packages/xgboost/libpath.py
```