### PR TITLE
Template `build/number` and place in header

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "1.7.6" %}
+{% set build_number = "0" %}
 
 package:
   name: xgboost-split
@@ -16,7 +17,7 @@ source:
     - 0001-Force-endian-flag-in-cross-compilation-mode.patch  # [arm64 or aarch64 or ppc64le]
 
 build:
-  number: 0
+  number: {{ build_number }}
   skip: true  # [win and cuda_compiler != "None"]
 
 requirements:


### PR DESCRIPTION
Simplify bumping the `build/number` by placing it in a Jinja variable at the top of the recipe. Even though it only is set once, it is simpler having this at the top next to the version, which may need to be changed at the same time, as opposed to digging into the recipe to find it.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
