### PR TITLE
Constrain `cuda-version` with `cuda_compiler_version`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ outputs:
       host:
         - nccl         # [linux and cuda_compiler != "None"]
       run:
-        - cuda-version >=11.2,<12  # [(cuda_compiler_version or "").startswith("11")]
+        - cuda-version >={{ cuda_compiler_version }},<12  # [(cuda_compiler_version or "").startswith("11")]
         - __cuda                   # [cuda_compiler != "None"]
 
   - name: _py-xgboost-mutex

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "1.7.6" %}
-{% set build_number = 4 %}
+{% set build_number = 5 %}
 
 package:
   name: xgboost-split


### PR DESCRIPTION
To ensure that CUDA 11.x built packages have a lower bound based on what CUDA version they were built with, use `cuda_compiler_version` (instead of hard-coding a value).

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
