### PR TITLE
Fix linter error from 2.1.0 (due to `noarch: python`)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,40 +8,40 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11:
-        CONFIG: linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11
+      linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython:
+        CONFIG: linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.8
-      linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12:
-        CONFIG: linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12
+      linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython:
+        CONFIG: linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12:
-        CONFIG: linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12
+      linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython:
+        CONFIG: linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11:
-        CONFIG: linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11
+      linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython:
+        CONFIG: linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.8
-      linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12:
-        CONFIG: linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12
+      linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython:
+        CONFIG: linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12:
-        CONFIG: linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12
+      ? linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython
+      : CONFIG: linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11:
-        CONFIG: linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11
+      linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython:
+        CONFIG: linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.8
-      linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12:
-        CONFIG: linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12
+      linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython:
+        CONFIG: linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12:
-        CONFIG: linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12
+      ? linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython
+      : CONFIG: linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,11 @@ jobs:
     vmImage: macOS-12
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_python3.8.____cpython:
+        CONFIG: osx_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_:
-        CONFIG: osx_arm64_
+      osx_arm64_python3.8.____cpython:
+        CONFIG: osx_arm64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,11 +8,11 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_cuda_compilerNonecuda_compiler_versionNone:
-        CONFIG: win_64_cuda_compilerNonecuda_compiler_versionNone
+      win_64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython:
+        CONFIG: win_64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0:
-        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0
+      win_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython:
+        CONFIG: win_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython.yaml
@@ -1,39 +1,47 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '16'
+- '11'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.8'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
-llvm_openmp:
-- '16'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-cuda:11.8
+nccl:
+- '2'
 pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
   r-base:
     min_pin: x.x
     max_pin: x.x
+python:
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
+  - cdt_name
+  - cuda_compiler
+  - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython.yaml
@@ -13,9 +13,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- cuda-nvcc
+- None
 cuda_compiler_version:
-- '12.0'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -32,7 +32,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython.yaml
@@ -25,13 +25,18 @@ docker_image:
 nccl:
 - '2'
 pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
   r-base:
     min_pin: x.x
     max_pin: x.x
+python:
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '11'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,21 +17,26 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- cuda-nvcc
+- nvcc
 cuda_compiler_version:
-- '12.0'
+- '11.8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '11'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-cuda:11.8
 nccl:
 - '2'
 pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
   r-base:
     min_pin: x.x
     max_pin: x.x
+python:
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython.yaml
@@ -1,11 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -13,25 +17,30 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
-- '11.8'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:11.8
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 nccl:
 - '2'
 pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
   r-base:
     min_pin: x.x
     max_pin: x.x
+python:
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython.yaml
@@ -17,9 +17,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -29,9 +29,14 @@ docker_image:
 nccl:
 - '2'
 pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
   r-base:
     min_pin: x.x
     max_pin: x.x
+python:
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython.yaml
@@ -32,11 +32,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython.yaml
@@ -1,15 +1,13 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '16'
+- '12'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,21 +17,31 @@ cuda_compiler:
 cuda_compiler_version:
 - None
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
-llvm_openmp:
-- '16'
-macos_machine:
-- arm64-apple-darwin20.0.0
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+nccl:
+- '2'
 pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
   r-base:
     min_pin: x.x
     max_pin: x.x
+python:
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
+  - cdt_name
+  - cuda_compiler
+  - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython.yaml
@@ -13,9 +13,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -32,11 +32,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -1,46 +1,44 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '11'
+- '16'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- nvcc
+- None
 cuda_compiler_version:
-- '11.8'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '11'
-docker_image:
-- quay.io/condaforge/linux-anvil-cuda:11.8
-nccl:
-- '2'
+- '16'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
   r-base:
     min_pin: x.x
     max_pin: x.x
+python:
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - c_stdlib_version
-  - cdt_name
-  - cuda_compiler
-  - cuda_compiler_version
-  - docker_image

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
+- '16'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- cos7
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,26 +19,26 @@ cuda_compiler:
 cuda_compiler_version:
 - None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
-nccl:
-- '2'
+- '16'
+llvm_openmp:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
 pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
   r-base:
     min_pin: x.x
     max_pin: x.x
+python:
+- 3.8.* *_cpython
 r_base:
 - '4.3'
 target_platform:
-- linux-ppc64le
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - c_stdlib_version
-  - cdt_name
-  - cuda_compiler
-  - cuda_compiler_version
-  - docker_image

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython.yaml
@@ -7,15 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- cuda-nvcc
+- None
 cuda_compiler_version:
-- '12.0'
+- None
 cxx_compiler:
 - vs2019
 m2w64_c_compiler:
 - m2w64-toolchain
 m2w64_cxx_compiler:
 - m2w64-toolchain
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython.yaml
@@ -7,15 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
 cxx_compiler:
 - vs2019
 m2w64_c_compiler:
 - m2w64-toolchain
 m2w64_cxx_compiler:
 - m2w64-toolchain
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
 target_platform:
 - win-64
 zip_keys:

--- a/README.md
+++ b/README.md
@@ -41,94 +41,94 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11</td>
+              <td>linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12</td>
+              <td>linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12</td>
+              <td>linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11</td>
+              <td>linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12</td>
+              <td>linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12</td>
+              <td>linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11</td>
+              <td>linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12</td>
+              <td>linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12</td>
+              <td>linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>osx_64_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64</td>
+              <td>osx_arm64_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cuda_compilerNonecuda_compiler_versionNone</td>
+              <td>win_64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilerNonecuda_compiler_versionNone" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0</td>
+              <td>win_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4403&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/xgboost-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "2.1.0" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set min_python = "3.8" %}
 
 {% set string_prefix = "cuda" ~ (cuda_compiler_version | replace('.', '')) %}  # [cuda_compiler_version != "None"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,18 @@ source:
 
 build:
   number: {{ build_number }}
-  noarch: python
+  # Make sure only one Python is built for as packages are `noarch: python`.
+  # However using `noarch: python` upsets the linter.
+  # So skip all Python's except the minimum Python version upstream supports
+  # xref: https://github.com/conda-forge/conda-smithy/issues/1887#issuecomment-2244323850
   # Windows CUDA 11.8 fails due to a compilation error
   # xref: https://github.com/conda-forge/xgboost-feedstock/issues/173
-  skip: True  # [win and cuda_compiler_version == "11.8"]
+  {% if python is defined and cuda_compiler_version is defined %}
+  skip: {{ (
+      python.split(".")[:2] != min_python.split(".")[:2] or
+      (win and cuda_compiler_version == "11.8")
+  ) }}
+  {% endif %}
 
 requirements:
   build:


### PR DESCRIPTION
The linter does not like having `noarch: python` at the top-level with selectors ( https://github.com/conda-forge/xgboost-feedstock/pull/167#issuecomment-2251573632 ) ( https://github.com/conda-forge/conda-smithy/issues/1887#issuecomment-2244323850 ). Rewriting the recipe without selectors is a substantial lift and not worth it given the move towards rattler-build.

However if we don't have `noarch` or a `skip` at the top-level, [a full matrix of Python versions is built out]( https://github.com/conda-forge/xgboost-feedstock/blob/977ee955301916df53fded647bca1aa6169b733a/.ci_support/linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml#L34-L39 ) for all Python XGBoost packages (despite these packages being redundant). Example below taken from [this CI run]( https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=907673&view=logs&j=cacb33e2-4f35-58d8-c6f0-bc569fa20097&t=5d96f9ff-2d0d-52ea-cc90-ffadc2f5efed&l=4136 ) ([attached log](https://github.com/user-attachments/files/16386551/xgboost-feedstock_linux_64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12_20240402.4.txt) for posterity):


<details>
<summary>Packages generated by Python matrix in past CI run:</summary>

```json
{
  "_py-xgboost-mutex-2.0-cpu_0.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "target_platform": "linux-64"
    }
  },
  "_r-xgboost-mutex-2.0-cpu_0.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "target_platform": "linux-64"
    }
  },
  "libxgboost-2.0.3-cpu_hce603c2_3.conda": {
    "recipe": {
      "__glibc": "__glibc >=2.17,<3.0.a0",
      "c_compiler": "gcc",
      "c_compiler_version": "12",
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "cuda_compiler_version": "None",
      "cxx_compiler": "gxx",
      "cxx_compiler_version": "12",
      "target_platform": "linux-64"
    }
  },
  "py-xgboost-2.0.3-cpu_pyh0a621ce_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.11.* *_cpython",
      "target_platform": "linux-64"
    }
  },
  "py-xgboost-2.0.3-cpu_pyh78d450f_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.10.* *_cpython",
      "target_platform": "linux-64"
    }
  },
  "py-xgboost-2.0.3-cpu_pyh995e691_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.8.* *_cpython",
      "target_platform": "linux-64"
    }
  },
  "py-xgboost-2.0.3-cpu_pyhbc962bd_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.12.* *_cpython",
      "target_platform": "linux-64"
    }
  },
  "py-xgboost-2.0.3-cpu_pyhc68e8b7_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.9.* *_cpython",
      "target_platform": "linux-64"
    }
  },
  "py-xgboost-cpu-2.0.3-pyh099c497_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.12.* *_cpython"
    }
  },
  "py-xgboost-cpu-2.0.3-pyh4f80c01_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.10.* *_cpython"
    }
  },
  "py-xgboost-cpu-2.0.3-pyhac85b48_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.9.* *_cpython"
    }
  },
  "py-xgboost-cpu-2.0.3-pyhb06c54e_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.11.* *_cpython"
    }
  },
  "py-xgboost-cpu-2.0.3-pyhb8f9a19_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.8.* *_cpython"
    }
  },
  "r-xgboost-2.0.3-cpu_r42h566b21a_3.conda": {
    "recipe": {
      "__glibc": "__glibc >=2.17,<3.0.a0",
      "c_compiler": "gcc",
      "c_compiler_version": "12",
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "cxx_compiler": "gxx",
      "cxx_compiler_version": "12",
      "target_platform": "linux-64"
    }
  },
  "r-xgboost-2.0.3-cpu_r43h566b21a_3.conda": {
    "recipe": {
      "__glibc": "__glibc >=2.17,<3.0.a0",
      "c_compiler": "gcc",
      "c_compiler_version": "12",
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "cxx_compiler": "gxx",
      "cxx_compiler_version": "12",
      "target_platform": "linux-64"
    }
  },
  "r-xgboost-cpu-2.0.3-r42hf5c67e3_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "target_platform": "linux-64"
    }
  },
  "r-xgboost-cpu-2.0.3-r43hf5c67e3_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "target_platform": "linux-64"
    }
  },
  "xgboost-2.0.3-cpu_pyh099c497_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.12.* *_cpython"
    }
  },
  "xgboost-2.0.3-cpu_pyh4f80c01_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.10.* *_cpython"
    }
  },
  "xgboost-2.0.3-cpu_pyhac85b48_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.9.* *_cpython"
    }
  },
  "xgboost-2.0.3-cpu_pyhb06c54e_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.11.* *_cpython"
    }
  },
  "xgboost-2.0.3-cpu_pyhb8f9a19_3.conda": {
    "recipe": {
      "channel_targets": "conda-forge main",
      "cuda_compiler": "None",
      "python": "3.8.* *_cpython"
    }
  }
}
```

</details>

To clean this up, we skip any Python version except the minimum one that XGBoost supports. This ensures we build for exactly one Python. To get the syntax right we need to use Jinja.

Unfortunately that means we need to consolidate our other `skip`s into this one, which includes the Windows CUDA 11.8 skip. So we do so and try to make the syntax as pleasing as we can within the constraints.

That all being said, this does keep the linter happy and it re-renders without generated unneeded Python builds.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
