### PR TITLE
Fix bot autoupdating parsing error

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,10 +29,11 @@ build:
   # Windows CUDA 11.8 fails due to a compilation error
   # xref: https://github.com/conda-forge/xgboost-feedstock/issues/173
   {% if python is defined and cuda_compiler_version is defined %}
-  skip: {{ (
-      python.split(".")[:2] != min_python.split(".")[:2] or
-      (win and cuda_compiler_version == "11.8")
-  ) }}
+  skip: >-
+    {{ (
+    python.split(".")[:2] != min_python.split(".")[:2] or
+    (win and cuda_compiler_version == "11.8")
+    ) }}
   {% endif %}
 
 requirements:


### PR DESCRIPTION
The autoupdate bot runs into a parsing error with the multiline Jinja expression used in the top-level `skip`. This places uses a multiline YAML string to hold the Jinja logic in a value associated with the `skip` key. This should make sure the bot can parse this logic correctly without getting hung up on the Jinja contained in it.

xref: https://github.com/conda-forge/xgboost-feedstock/pull/180#issuecomment-2259309773

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
