### PR TITLE
Align `string_prefix` across dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ build:
   # xref: https://github.com/conda-forge/xgboost-feedstock/issues/173
   {% if python is defined and cuda_compiler_version is defined %}
   skip: >-
-    {{ ( python.split(".")[:2] != min_python.split(".")[:2] or (win and cuda_compiler_version == "11.8") ) }}
+    {{ python.split(".")[:2] != min_python.split(".")[:2] or (win and cuda_compiler_version == "11.8") }}
   {% endif %}
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -113,12 +113,14 @@ outputs:
       host:
         - {{ pin_subpackage('_py-xgboost-mutex', exact=True) }}
         - {{ pin_subpackage('libxgboost', max_pin='x.x.x') }}
+        - libxgboost =*={{ string_prefix }}_h*_{{ PKG_BUILDNUM }}
         - python >={{ min_python }}
         - hatchling >=1.12.1
         - pip
       run:
         - {{ pin_subpackage('_py-xgboost-mutex', exact=True) }}
         - {{ pin_subpackage('libxgboost', max_pin='x.x.x') }}
+        - libxgboost =*={{ string_prefix }}_h*_{{ PKG_BUILDNUM }}
         - python >={{ min_python }}
         - numpy
         - scipy
@@ -139,9 +141,11 @@ outputs:
       host:
         - python >={{ min_python }}
         - {{ pin_subpackage('py-xgboost', exact=True) }}
+        - py-xgboost =*={{ string_prefix }}_pyh*_{{ PKG_BUILDNUM }}
       run:
         - python >={{ min_python }}
         - {{ pin_subpackage('py-xgboost', exact=True) }}
+        - py-xgboost =*={{ string_prefix }}_pyh*_{{ PKG_BUILDNUM }}
     test:
       requires:
         - python
@@ -156,9 +160,11 @@ outputs:
       host:
         - python >={{ min_python }}
         - {{ pin_subpackage('py-xgboost', exact=True) }}
+        - py-xgboost =*={{ string_prefix }}_pyh*_{{ PKG_BUILDNUM }}
       run:
         - python >={{ min_python }}
         - {{ pin_subpackage('py-xgboost', exact=True) }}
+        - py-xgboost =*={{ string_prefix }}_pyh*_{{ PKG_BUILDNUM }}
         - __cuda  # [cuda_compiler != "None"]
     test:
       requires:
@@ -174,9 +180,11 @@ outputs:
       host:
         - python >={{ min_python }}
         - {{ pin_subpackage('py-xgboost', exact=True) }}
+        - py-xgboost =*={{ string_prefix }}_pyh*_{{ PKG_BUILDNUM }}
       run:
         - python >={{ min_python }}
         - {{ pin_subpackage('py-xgboost', exact=True) }}
+        - py-xgboost =*={{ string_prefix }}_pyh*_{{ PKG_BUILDNUM }}
         - __cuda  # [cuda_compiler != "None"]
     test:
       requires:
@@ -228,6 +236,7 @@ outputs:
       host:
         - {{ pin_subpackage('_r-xgboost-mutex', exact=True) }}
         - {{ pin_subpackage('libxgboost', max_pin='x.x.x') }}
+        - libxgboost =*={{ string_prefix }}_h*_{{ PKG_BUILDNUM }}
         - r-base
         - r-matrix
         - r-data.table
@@ -237,6 +246,7 @@ outputs:
       run:
         - {{ pin_subpackage('_r-xgboost-mutex', exact=True) }}
         - {{ pin_subpackage('libxgboost', max_pin='x.x.x') }}
+        - libxgboost =*={{ string_prefix }}_h*_{{ PKG_BUILDNUM }}
         - r-base
         - r-matrix
         - r-data.table
@@ -259,9 +269,11 @@ outputs:
       host:
         - r-base
         - {{ pin_subpackage('r-xgboost', exact=True) }}
+        - r-xgboost =*={{ string_prefix }}_r*h*_{{ PKG_BUILDNUM }}
       run:
         - r-base
         - {{ pin_subpackage('r-xgboost', exact=True) }}
+        - r-xgboost =*={{ string_prefix }}_r*h*_{{ PKG_BUILDNUM }}
     test:
       requires:
         - r-base
@@ -277,9 +289,11 @@ outputs:
       host:
         - r-base
         - {{ pin_subpackage('r-xgboost', exact=True) }}
+        - r-xgboost =*={{ string_prefix }}_r*h*_{{ PKG_BUILDNUM }}
       run:
         - r-base
         - {{ pin_subpackage('r-xgboost', exact=True) }}
+        - r-xgboost =*={{ string_prefix }}_r*h*_{{ PKG_BUILDNUM }}
         - __cuda  # [cuda_compiler != "None"]
     test:
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "2.1.1" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set min_python = "3.8" %}
 
 {% set string_prefix = "cuda" ~ (cuda_compiler_version | replace('.', '')) if (cuda_compiler_version or "None") != "None" else "cpu" %}


### PR DESCRIPTION
As observed in @trivialfis 's comment ( https://github.com/conda-forge/xgboost-feedstock/pull/167#issuecomment-2254230678 ), the packages here do not sufficiently constrain the CUDA version. To fix this, make sure that the `string_prefix` matches across dependencies (in addition to properly constraining the version number)

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
