### PR TITLE
Skip flaky R test on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -265,7 +265,7 @@ outputs:
       files:
         - test-r-xgboost.r
       commands:
-        - Rscript test-r-xgboost.r  # [not (win and cuda_compiler != "None")]
+        - Rscript test-r-xgboost.r  # [not win]
 
   - name: r-xgboost-cpu
     build:


### PR DESCRIPTION
This test had failed on Windows CUDA, but it was seen to fail on Windows CPU builds too. It was skipped just for Windows CUDA builds, but then failed on `main` with Windows CPU. So this just skips the test on Windows entirely. There is already an open issue to investigate fixing this (linked below). Will update with this information.

xref: https://github.com/conda-forge/xgboost-feedstock/issues/205

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
