### PR TITLE
[NO MRG, TST] Apply XGBoost patch for using RMM's CCCL

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
     - patches/0001-Enable-latest-libcxx-on-MacOS.patch                # [osx]
     - patches/0002-Remove-nvidia-nccl-cu12-from-pyproject.toml.patch
     - patches/0003-Mark-wheels-as-any-platform-compatible.patch
+    - patches/0004-Use-RMM-s-pached-CCCL.patch                        # [linux]
 
 build:
   number: {{ build_number }}

--- a/recipe/patches/0004-Use-RMM-s-pached-CCCL.patch
+++ b/recipe/patches/0004-Use-RMM-s-pached-CCCL.patch
@@ -1,0 +1,75 @@
+From 680878a21a29298f5b0d5ced331598811ec47c87 Mon Sep 17 00:00:00 2001
+From: jakirkham <jakirkham@gmail.com>
+Date: Wed, 19 Mar 2025 19:40:18 -0700
+Subject: [PATCH] Use RMM's pached CCCL
+
+Make sure to search for RMM if it will be used. This should pick up the
+patched CCCL from RMM.
+
+If RMM is not being used and this is a CUDA build, search for CCCL
+explicitly.
+---
+ CMakeLists.txt | 40 ++++++++++++++++++++++------------------
+ 1 file changed, 22 insertions(+), 18 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5fb464b67..177999a50 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -224,24 +224,6 @@ if(USE_CUDA)
+   add_subdirectory(${PROJECT_SOURCE_DIR}/gputreeshap)
+ 
+   find_package(CUDAToolkit REQUIRED)
+-  find_package(CCCL CONFIG)
+-  if(NOT CCCL_FOUND)
+-    message(STATUS "Standalone CCCL not found. Attempting to use CCCL from CUDA Toolkit...")
+-    find_package(CCCL CONFIG
+-      HINTS ${CUDAToolkit_LIBRARY_DIR}/cmake)
+-    if(NOT CCCL_FOUND)
+-      message(STATUS "Could not locate CCCL from CUDA Toolkit. Using Thrust and CUB from CUDA Toolkit...")
+-      find_package(libcudacxx CONFIG REQUIRED
+-        HINTS ${CUDAToolkit_LIBRARY_DIR}/cmake)
+-      find_package(CUB CONFIG REQUIRED
+-        HINTS ${CUDAToolkit_LIBRARY_DIR}/cmake)
+-      find_package(Thrust CONFIG REQUIRED
+-        HINTS ${CUDAToolkit_LIBRARY_DIR}/cmake)
+-      thrust_create_target(Thrust HOST CPP DEVICE CUDA)
+-      add_library(CCCL::CCCL INTERFACE IMPORTED GLOBAL)
+-      target_link_libraries(CCCL::CCCL INTERFACE libcudacxx::libcudacxx CUB::CUB Thrust)
+-    endif()
+-  endif()
+ endif()
+ 
+ if(FORCE_COLORED_OUTPUT AND (CMAKE_GENERATOR STREQUAL "Ninja") AND
+@@ -327,6 +309,28 @@ if(PLUGIN_RMM)
+   list(REMOVE_ITEM rmm_link_libs CUDA::cudart)
+   list(APPEND rmm_link_libs CUDA::cudart_static)
+   set_target_properties(rmm::rmm PROPERTIES INTERFACE_LINK_LIBRARIES "${rmm_link_libs}")
++
++  # Pick up patched CCCL from RMM
++elseif(USE_CUDA)
++  # If using CUDA and not RMM, search for CCCL.
++  find_package(CCCL CONFIG)
++  if(NOT CCCL_FOUND)
++    message(STATUS "Standalone CCCL not found. Attempting to use CCCL from CUDA Toolkit...")
++    find_package(CCCL CONFIG
++      HINTS ${CUDAToolkit_LIBRARY_DIR}/cmake)
++    if(NOT CCCL_FOUND)
++      message(STATUS "Could not locate CCCL from CUDA Toolkit. Using Thrust and CUB from CUDA Toolkit...")
++      find_package(libcudacxx CONFIG REQUIRED
++        HINTS ${CUDAToolkit_LIBRARY_DIR}/cmake)
++      find_package(CUB CONFIG REQUIRED
++        HINTS ${CUDAToolkit_LIBRARY_DIR}/cmake)
++      find_package(Thrust CONFIG REQUIRED
++        HINTS ${CUDAToolkit_LIBRARY_DIR}/cmake)
++      thrust_create_target(Thrust HOST CPP DEVICE CUDA)
++      add_library(CCCL::CCCL INTERFACE IMPORTED GLOBAL)
++      target_link_libraries(CCCL::CCCL INTERFACE libcudacxx::libcudacxx CUB::CUB Thrust)
++    endif()
++  endif()
+ endif()
+ 
+ if(PLUGIN_SYCL)
+-- 
+2.49.0
+


### PR DESCRIPTION
Tries out this upstream change to use RMM's CCCL: https://github.com/dmlc/xgboost/pull/11353 ( based on https://github.com/dmlc/xgboost/pull/11351 )

As this feedstock does not currently use RMM, this should help validate the patch retains the unpatched behavior unchanged

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
