### PR TITLE
Remove `dmlc`'s `CMake` directory

### DIFF
--- a/recipe/install-libxgboost.sh
+++ b/recipe/install-libxgboost.sh
@@ -7,7 +7,9 @@ pushd build-target
 
     rm -fv "${PREFIX}/lib/libdmlc.a"
     rm -rfv "${PREFIX}/include/dmlc"
+    rm -rfv "${PREFIX}/lib/cmake/dmlc"
     rm -fv "${LIBRARY_PREFIX}/mingw-w64/lib/dmlc.lib"
+    rm -rfv "${LIBRARY_PREFIX}/mingw-w64/lib/cmake/dmlc"
     rm -rfv "${LIBRARY_PREFIX}/mingw-w64/include/dmlc"
 
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -93,12 +93,14 @@ outputs:
         - test -f "${PREFIX}/lib/libxgboost${SHLIB_EXT}"                  # [unix]
         - test ! -f "${PREFIX}/lib/libdmlc.a"                             # [unix]
         - test -d "${PREFIX}/lib/cmake"                                   # [unix]
+        - test ! -d "${PREFIX}/lib/cmake/dmlc"                              # [unix] 
         - test ! -d "${PREFIX}/include/dmlc"                              # [unix]
         - if not exist %LIBRARY_PREFIX%\mingw-w64\lib\xgboost.lib exit 1  # [win]
         - if not exist %LIBRARY_PREFIX%\mingw-w64\bin\xgboost.dll exit 1  # [win]
         - if exist %LIBRARY_PREFIX%\mingw-w64\lib\dmlc.lib exit 1          # [win]
         - if exist %LIBRARY_PREFIX%\mingw-w64\include\dmlc exit 1          # [win]
         - if not exist %LIBRARY_PREFIX%\mingw-w64\lib\cmake exit 1        # [win]
+        - if exist %LIBRARY_PREFIX%\mingw-w64\lib\cmake\dmlc exit 1          # [win]
 
   - name: py-xgboost
     script: >-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.0.1" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set python_min = "3.10" %}
 {% set posix = 'm2-' if win else '' %}
 


### PR DESCRIPTION
Follow up on issue: https://github.com/conda-forge/xgboost-feedstock/issues/236

Removes `dmlc`'s `cmake` directory from `libxgboost`'s install.